### PR TITLE
Fix Finder corner sharpening and disable diagnostic logs

### DIFF
--- a/src/sharpener/Dock/dock.m
+++ b/src/sharpener/Dock/dock.m
@@ -138,12 +138,7 @@ void toggleDockCorners(BOOL enable, NSInteger radius) {
 static void setupDockNotifications(void) __attribute__((constructor));
 static void setupDockNotifications(void) {
     // Only setup if we're in the Dock process
-    if (!isDockProcess()) {
-        NSLog(@"[AppleSharpener] Not in Dock process (bundle ID: %@), skipping setup", [[NSBundle mainBundle] bundleIdentifier]);
-        return;
-    }
-    
-    NSLog(@"[AppleSharpener] Setting up dock notifications in process: %@", [[NSBundle mainBundle] bundleIdentifier]);
+    if (!isDockProcess()) return;
     
     // Load persisted settings from NSUserDefaults
     NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"com.aspauldingcode.apple_sharpener"];

--- a/src/sharpener/Windows/window.m
+++ b/src/sharpener/Windows/window.m
@@ -34,7 +34,8 @@ static inline BOOL isStandardAppWindow(NSWindow *window) {
     if (mask & (NSWindowStyleMaskHUDWindow | NSWindowStyleMaskUtilityWindow)) return NO;
     
     // Exclude context menus, tooltips, and other transient windows
-    if (window.level != NSNormalWindowLevel) return NO;
+    // Relaxed window level check to allow Finder and other system windows
+    // if (window.level != NSNormalWindowLevel) return NO;
     
     // Exclude very small windows (likely UI elements)
     NSRect frame = window.frame;
@@ -97,8 +98,6 @@ static void setupWindowNotifications(void) {
     [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowDidBecomeKeyNotification object:nil queue:nil usingBlock:^(NSNotification *notification) {
         applyCornerRadiusToWindow(notification.object);
     }];
-
-    NSLog(@"[AppleSharpener] Windows: Loaded enableSharpener: %d, customRadius: %ld", enableSharpener, (long)customRadius);
 
     toggleSquareCorners(enableSharpener, customRadius);
 
@@ -188,6 +187,16 @@ static void setupWindowNotifications(void) {
 }
 
 - (id)_cornerMask {
+    if (enableSharpener && customRadius == 0 && isStandardAppWindow(self)) {
+        // Create a 1x1 white image for square corners
+        NSImage *squareCornerMask = [[NSImage alloc] initWithSize:NSMakeSize(1, 1)];
+        [squareCornerMask lockFocus];
+        [[NSColor whiteColor] set];
+        NSRectFill(NSMakeRect(0, 0, 1, 1));
+        [squareCornerMask unlockFocus];
+        return squareCornerMask;
+    }
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
     return ZKOrig(id);
@@ -216,8 +225,8 @@ ZKSwizzleInterfaceGroup(AS_TitlebarDecorationView, _NSTitlebarDecorationView, NS
 }
 
 - (void)drawRect:(NSRect)dirtyRect {
-    if (enableSharpener && customRadius != 0 && isStandardAppWindow(self.window)) {
-        return;  // Suppress drawing when custom radius is used (but not when radius is 0)
+    if (enableSharpener && isStandardAppWindow(self.window)) {
+        return;  // Suppress drawing when sharpener is enabled to ensure corners remain sharp
     }
     
 #pragma clang diagnostic push


### PR DESCRIPTION
## Summary
- Relaxed window detection logic by removing the strict `NSNormalWindowLevel` check, allowing Finder and other system windows to be sharpened.
- Re-implemented `_cornerMask` to return a 1x1 white image when the radius is 0, forcing sharp corners on system windows.
- Updated `_NSTitlebarDecorationView` to suppress drawing whenever sharpening is enabled, preventing rounded elements from rendering.
- Disabled verbose diagnostic logs in both Dock and Windows modules.