### PR TITLE
Fix shadow removal in Safari, enhance window sharpening, and add shadow control CLI

### DIFF
--- a/src/sharpener/Dock/dock.m
+++ b/src/sharpener/Dock/dock.m
@@ -138,12 +138,7 @@ void toggleDockCorners(BOOL enable, NSInteger radius) {
 static void setupDockNotifications(void) __attribute__((constructor));
 static void setupDockNotifications(void) {
     // Only setup if we're in the Dock process
-    if (!isDockProcess()) {
-        NSLog(@"[AppleSharpener] Not in Dock process (bundle ID: %@), skipping setup", [[NSBundle mainBundle] bundleIdentifier]);
-        return;
-    }
-    
-    NSLog(@"[AppleSharpener] Setting up dock notifications in process: %@", [[NSBundle mainBundle] bundleIdentifier]);
+    if (!isDockProcess()) return;
     
     // Load persisted settings from NSUserDefaults
     NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"com.aspauldingcode.apple_sharpener"];

--- a/src/sharpener/Windows/window.h
+++ b/src/sharpener/Windows/window.h
@@ -15,4 +15,10 @@
  */
 void toggleSquareCorners(BOOL enable, NSInteger radius);
 
+/**
+ * Toggle window shadows for application windows
+ * @param remove Whether to remove window shadows
+ */
+void toggleWindowShadows(BOOL remove);
+
 #endif /* WINDOW_H */

--- a/src/sharpener/Windows/window.m
+++ b/src/sharpener/Windows/window.m
@@ -34,7 +34,8 @@ static inline BOOL isStandardAppWindow(NSWindow *window) {
     if (mask & (NSWindowStyleMaskHUDWindow | NSWindowStyleMaskUtilityWindow)) return NO;
     
     // Exclude context menus, tooltips, and other transient windows
-    if (window.level != NSNormalWindowLevel) return NO;
+    // Relaxed window level check to allow Finder and other system windows
+    // if (window.level != NSNormalWindowLevel) return NO;
     
     // Exclude very small windows (likely UI elements)
     NSRect frame = window.frame;
@@ -97,8 +98,6 @@ static void setupWindowNotifications(void) {
     [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowDidBecomeKeyNotification object:nil queue:nil usingBlock:^(NSNotification *notification) {
         applyCornerRadiusToWindow(notification.object);
     }];
-
-    NSLog(@"[AppleSharpener] Windows: Loaded enableSharpener: %d, customRadius: %ld", enableSharpener, (long)customRadius);
 
     toggleSquareCorners(enableSharpener, customRadius);
 
@@ -188,6 +187,16 @@ static void setupWindowNotifications(void) {
 }
 
 - (id)_cornerMask {
+    if (enableSharpener && customRadius == 0 && isStandardAppWindow(self)) {
+        // Create a 1x1 white image for square corners
+        NSImage *squareCornerMask = [[NSImage alloc] initWithSize:NSMakeSize(1, 1)];
+        [squareCornerMask lockFocus];
+        [[NSColor whiteColor] set];
+        NSRectFill(NSMakeRect(0, 0, 1, 1));
+        [squareCornerMask unlockFocus];
+        return squareCornerMask;
+    }
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
     return ZKOrig(id);
@@ -216,8 +225,8 @@ ZKSwizzleInterfaceGroup(AS_TitlebarDecorationView, _NSTitlebarDecorationView, NS
 }
 
 - (void)drawRect:(NSRect)dirtyRect {
-    if (enableSharpener && customRadius != 0 && isStandardAppWindow(self.window)) {
-        return;  // Suppress drawing when custom radius is used (but not when radius is 0)
+    if (enableSharpener && isStandardAppWindow(self.window)) {
+        return;  // Suppress drawing when sharpener is enabled to ensure corners remain sharp
     }
     
 #pragma clang diagnostic push

--- a/src/sharpener/Windows/window.m
+++ b/src/sharpener/Windows/window.m
@@ -13,10 +13,12 @@
 static BOOL enableSharpener = YES;
 static BOOL enableCustomRadius = YES;
 static NSInteger customRadius = 0;
+static BOOL removeShadows = NO;
 
 #pragma mark - Forward Declarations
 
 void toggleSquareCorners(BOOL enable, NSInteger radius);
+void toggleWindowShadows(BOOL remove);
 static void setupWindowNotifications(void) __attribute__((constructor));
 
 #pragma mark - Helper Functions
@@ -27,15 +29,11 @@ static inline BOOL isStandardAppWindow(NSWindow *window) {
     if (!window) return NO;
     NSWindowStyleMask mask = window.styleMask;
     
-    // Only apply to standard titled windows, exclude system UI elements
+    // Only apply to standard titled windows
     if (!(mask & NSWindowStyleMaskTitled)) return NO;
     
     // Exclude HUD, utility, and other system windows
     if (mask & (NSWindowStyleMaskHUDWindow | NSWindowStyleMaskUtilityWindow)) return NO;
-    
-    // Exclude context menus, tooltips, and other transient windows
-    // Relaxed window level check to allow Finder and other system windows
-    // if (window.level != NSNormalWindowLevel) return NO;
     
     // Exclude very small windows (likely UI elements)
     NSRect frame = window.frame;
@@ -47,9 +45,17 @@ static inline BOOL isStandardAppWindow(NSWindow *window) {
 static void applyCornerRadiusToWindow(NSWindow *window) {
     if (!window || !enableSharpener) return;
     if (!isStandardAppWindow(window)) return;
-    if (!(enableSharpener && enableCustomRadius)) return;
     
-    [(id)window setValue:@(customRadius) forKey:@"cornerRadius"];
+    if (enableSharpener && enableCustomRadius) {
+        [(id)window setValue:@(customRadius) forKey:@"cornerRadius"];
+    }
+    
+    if (removeShadows) {
+        [window setHasShadow:NO];
+    } else {
+        [window setHasShadow:YES];
+    }
+    
     [window invalidateShadow];
 }
 
@@ -63,10 +69,27 @@ void toggleSquareCorners(BOOL enable, NSInteger radius) {
     
     if (stateChanged) {
         for (NSWindow *window in [NSApplication sharedApplication].windows) {
-            if (enableSharpener && enableCustomRadius) {
+            if (enableSharpener) {
                 applyCornerRadiusToWindow(window);
             } else if (isStandardAppWindow(window)) {
                 [(id)window setValue:@0 forKey:@"cornerRadius"];
+                [window setHasShadow:YES];
+                [window invalidateShadow];
+            }
+        }
+    }
+}
+
+void toggleWindowShadows(BOOL remove) {
+    BOOL stateChanged = (removeShadows != remove);
+    removeShadows = remove;
+    
+    if (stateChanged) {
+        for (NSWindow *window in [NSApplication sharedApplication].windows) {
+            if (enableSharpener) {
+                applyCornerRadiusToWindow(window);
+            } else if (isStandardAppWindow(window)) {
+                [window setHasShadow:!removeShadows];
                 [window invalidateShadow];
             }
         }
@@ -81,13 +104,14 @@ static void setupWindowNotifications(void) {
 
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    static const char *kNotifyEnabled = "com.aspauldingcode.apple_sharpener.enabled";
     static const char *kNotifyRadius  = "com.aspauldingcode.apple_sharpener.set_radius";
+    static const char *kNotifyShadows = "com.aspauldingcode.apple_sharpener.remove_shadows";
 
     // Load persisted state from NSUserDefaults
     NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"com.aspauldingcode.apple_sharpener"];
     enableSharpener = [defaults boolForKey:@"enabled"];
     customRadius = [defaults integerForKey:@"radius"];
+    removeShadows = [defaults boolForKey:@"remove_shadows"];
 
     // Add observers for multiple window events to catch all window creation scenarios
     // Add observers for window events to apply corner radius when windows become active
@@ -135,12 +159,37 @@ static void setupWindowNotifications(void) {
         [defaults setInteger:customRadius forKey:@"radius"];
         [defaults synchronize];
     });
+
+    int tokenShadows = 0;
+    notify_register_dispatch(kNotifyShadows, &tokenShadows, queue, ^(int t){
+        uint64_t state = 0;
+        if (notify_get_state(t, &state) == NOTIFY_STATUS_OK) {
+            toggleWindowShadows((BOOL)state);
+        }
+        [defaults setBool:removeShadows forKey:@"remove_shadows"];
+        [defaults synchronize];
+    });
 }
 
 #pragma mark - Swizzled NSWindow
 
  ZKSwizzleInterfaceGroup(AS_NSWindow_CornerRadius, NSWindow, NSWindow, APPLE_SHARPENER)
 @implementation AS_NSWindow_CornerRadius
+
+- (BOOL)hasShadow {
+    if (removeShadows && isStandardAppWindow(self)) {
+        return NO;
+    }
+    return ZKOrig(BOOL);
+}
+
+- (void)setHasShadow:(BOOL)hasShadow {
+    if (removeShadows && isStandardAppWindow(self)) {
+        ZKOrig(void, NO);
+    } else {
+        ZKOrig(void, hasShadow);
+    }
+}
 
 - (void)setFrame:(NSRect)frameRect display:(BOOL)flag {
 #pragma clang diagnostic push
@@ -207,31 +256,6 @@ static void setupWindowNotifications(void) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
     ZKOrig(void, sender);
-#pragma clang diagnostic pop
-}
-
-@end
-
-#pragma mark - Swizzled Titlebar Decoration View
-
-ZKSwizzleInterfaceGroup(AS_TitlebarDecorationView, _NSTitlebarDecorationView, NSView, APPLE_SHARPENER)
-@implementation AS_TitlebarDecorationView
-
-- (void)viewDidMoveToWindow {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
-    ZKOrig(void);
-#pragma clang diagnostic pop
-}
-
-- (void)drawRect:(NSRect)dirtyRect {
-    if (enableSharpener && isStandardAppWindow(self.window)) {
-        return;  // Suppress drawing when sharpener is enabled to ensure corners remain sharp
-    }
-    
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
-    ZKOrig(void, dirtyRect);
 #pragma clang diagnostic pop
 }
 

--- a/src/sharpener/clitool.m
+++ b/src/sharpener/clitool.m
@@ -13,6 +13,7 @@ void printUsage() {
          "\n\nOptions:"
          "\n  -r, --radius <value>   Set sharpening radius"
          "\n  -d, --dock-radius <value>  Set dock radius"
+         "\n  --shadows [on|off]     Toggle window shadows (default: on)"
          "\n  -s, --status           Show current radius and status"
          "\n  -v, --version          Show version"
          "\n  -h, --help             Show this help message\n");
@@ -121,6 +122,30 @@ int main(int argc, const char * argv[]) {
                 printf("Failed to register dock set_radius notification\n");
                 return 1;
             }
+        } else if ([firstArg isEqualToString:@"--shadows"] && argc > 2) {
+            NSString *shadowArg = [NSString stringWithUTF8String:argv[2]];
+            BOOL remove = NO;
+            if ([shadowArg isEqualToString:@"off"]) {
+                remove = YES;
+            } else if ([shadowArg isEqualToString:@"on"]) {
+                remove = NO;
+            } else {
+                printf("Invalid shadow state: %s. Use 'on' or 'off'.\n", [shadowArg UTF8String]);
+                return 1;
+            }
+            
+            int tokenShadows = 0;
+            if (notify_register_check("com.aspauldingcode.apple_sharpener.remove_shadows", &tokenShadows) == NOTIFY_STATUS_OK) {
+                notify_set_state(tokenShadows, remove);
+                notify_post("com.aspauldingcode.apple_sharpener.remove_shadows");
+                NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"com.aspauldingcode.apple_sharpener"];
+                [defaults setBool:remove forKey:@"remove_shadows"];
+                [defaults synchronize];
+                printf("Window shadows %s\n", remove ? "disabled" : "enabled");
+            } else {
+                printf("Failed to register shadows notification\n");
+                return 1;
+            }
         } else if ([firstArg isEqualToString:@"--status"] || [firstArg isEqualToString:@"-s"]) {
             // Read the current radius from the shared state on the set_radius channel
             int tokenShowRadius = 0;
@@ -162,9 +187,11 @@ int main(int argc, const char * argv[]) {
             }
             NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"com.aspauldingcode.apple_sharpener"];
             BOOL persistedEnabled = [defaults boolForKey:@"enabled"];
+            BOOL removeShadows = [defaults boolForKey:@"remove_shadows"];
             enabledState = persistedEnabled ? 1 : 0;  // Use persisted value if needed
             printf("Current radius: %llu\n", currentRadius);
             printf("Current dock radius: %llu\n", currentDockRadius);
+            printf("Window shadows: %s\n", removeShadows ? "off" : "on");
             printf("Status: %s\n", enabledState ? "on" : "off");
         } else {
             printf("Unknown command: %s\n", [firstArg UTF8String]);


### PR DESCRIPTION
## Summary
- **Safari Shadow Fix:** Implemented persistent shadow removal for Safari by swizzling `hasShadow` and `setHasShadow:` in `NSWindow`.
- **Keyboard Shortcut Restoration:** Removed intrusive `_NSTitlebarDecorationView` swizzling that was interfering with Safari's tab-navigation shortcuts.
- **Enhanced Window Sharpening:** Fixed Finder corner sharpening issues and improved the robustness of the corner mask application for square windows.
- **Shadow Control CLI:** Added a new `--shadows [on|off]` option to the `sharpener` tool for real-time and persistent shadow management.
- **Stability Improvements:** Refined window filtering and removed redundant diagnostic logging to reduce system overhead.